### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,9 @@
     "grunt-mocha-phantomjs": "^0.6.0",
     "grunt-mocha-test": "^0.12.7",
     "mocha": "^2.1.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/the-grid/Flowerflip.git"
   }
 }


### PR DESCRIPTION
This pull request adds the repository field to `package.json`.

It will prevent a warning when using `npm` and should also add a link to the page on GitHub from the npm package page at https://www.npmjs.com/package/flowerflip