### PR TITLE
Fix coffeeify transform dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "chai": "^2.0.0",
     "coffee-script": "^1.9.0",
+    "coffeeify": "^1.0.0",
     "debug": "~2.1.1",
     "graphlib": "^1.0.1",
     "graphlib-dot": "^0.6.1"
@@ -25,9 +26,6 @@
       "url": "https://github.com/the-grid/Flowerflip/raw/master/LICENSE"
     }
   ],
-  "dependencies": {
-    "coffeeify": "^1.0.0"
-  },
   "devDependencies": {
     "coffeelint": "^1.8.1",
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
       "url": "https://github.com/the-grid/Flowerflip/raw/master/LICENSE"
     }
   ],
+  "dependencies": {
+    "coffeeify": "^1.0.0"
+  },
   "devDependencies": {
-    "coffeeify": "^1.0.0",
     "coffeelint": "^1.8.1",
     "grunt": "^0.4.5",
     "grunt-browserify": "^3.5.0",


### PR DESCRIPTION
This pull request fixes an issue where Flowerflip is a dependency but coffeeify is missing.

The browserify README [says the following](https://github.com/substack/node-browserify#browserifytransform) about specifying source transforms in the browserify.transform field of package.json:

> Make sure to add transforms to your package.json dependencies field.