### PR TITLE
Updated grunt-browserify to version 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "coffeelint": "1.13.0",
     "grunt": "0.4.5",
-    "grunt-browserify": "3.8.0",
+    "grunt-browserify": "4.0.1",
     "grunt-coffeelint": "0.0.13",
     "grunt-contrib-coffee": "0.12.0",
     "grunt-mocha-phantomjs": "0.6.2",


### PR DESCRIPTION
:rocket:

grunt-browserify just published version 4.0.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 14 commits (ahead by 14, behind by 0).

- [3565b89](https://github.com/jmreidy/grunt-browserify/commit/3565b89c3d9964e52b8c3c8a035276f3d6a2f174): 4.0.1
- [444f150](https://github.com/jmreidy/grunt-browserify/commit/444f15027018561c4a5489c89f80b739bdd73093): Merge pull request #355 from berniegp/issue-354
- [a78f32f](https://github.com/jmreidy/grunt-browserify/commit/a78f32f46d9ea588c19a067e8859814290f3bbea): fixes travis jshint errors
- [74d4e0e](https://github.com/jmreidy/grunt-browserify/commit/74d4e0e1412a4869de601ab7d5746a8977b361a7): Remove fullPaths option when using watchify
- [c0a71f0](https://github.com/jmreidy/grunt-browserify/commit/c0a71f066050a77af0c613f51538b0aff3be634e): Merge pull request #346 from modernlegend/remove_trailing_comma
- [8584629](https://github.com/jmreidy/grunt-browserify/commit/85846299e217ae98f15b41392037ae15f108219d): remove trailing comma
- [30d2b0f](https://github.com/jmreidy/grunt-browserify/commit/30d2b0fcdb96054170fa1515f2450a3bfd212d52): 4.0.0
- [f34549d](https://github.com/jmreidy/grunt-browserify/commit/f34549d22cc4f65b4a534a7c186ce9d09fe502a4): 3.9.0
- [9207fac](https://github.com/jmreidy/grunt-browserify/commit/9207fac4d24e3eecbf80063e02cb833917dbb019): Merge pull request #341 from zertosh/master
- [6ce1312](https://github.com/jmreidy/grunt-browserify/commit/6ce1312dd2592668670d6d759f12fe0e4f930ef9): Use browserify@^11.0.1 and watchify@^3.3.1
- [91f3eba](https://github.com/jmreidy/grunt-browserify/commit/91f3eba5ad905881bf4def96db385a954b2f7180): Merge pull request #336 from danielepolencic/master
- [11b5ec1](https://github.com/jmreidy/grunt-browserify/commit/11b5ec1d7ce1aa53e16bc495f3a1e26aa08be34f): Merge pull request #338 from bennyn/patch-1
- [e783623](https://github.com/jmreidy/grunt-browserify/commit/e7836230cb805f6c256ce7f6ad09effa770b3982): Added missing closing brackets for 'remapify' example
- [d158437](https://github.com/jmreidy/grunt-browserify/commit/d158437e632fcd40a35868f891590574eba563a3): updated watchify dependency

See the [full diff](https://github.com/jmreidy/grunt-browserify/compare/8f1f07cfface48d1e3ba820e5606c07d74eee0d8...3565b89c3d9964e52b8c3c8a035276f3d6a2f174).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>